### PR TITLE
fix: don't insert text after cursor

### DIFF
--- a/lua/ts-autotag/close_tag.lua
+++ b/lua/ts-autotag/close_tag.lua
@@ -28,7 +28,7 @@ function M.maybe_close_tag(bufnr)
 
 	text = string.format("</%s>", text)
 
-	vim.api.nvim_put({ text }, "", true, false)
+	vim.api.nvim_put({ text }, "", false, false)
 	vim.api.nvim_win_set_cursor(0, cursor)
 end
 


### PR DESCRIPTION
closes #3