### PR TITLE
feat: aliases support

### DIFF
--- a/lua/ts-autotag/close_tag.lua
+++ b/lua/ts-autotag/close_tag.lua
@@ -5,7 +5,8 @@ local M = {}
 
 ---@param bufnr integer
 local function maybe_close_tag(bufnr)
-	local ok, parser = pcall(vim.treesitter.get_parser, bufnr)
+	local aliased_lang = ts.get_aliased_lang(bufnr)
+	local ok, parser = pcall(vim.treesitter.get_parser, bufnr, aliased_lang)
 	if not ok or not parser then
 		return
 	end

--- a/lua/ts-autotag/config.lua
+++ b/lua/ts-autotag/config.lua
@@ -2,6 +2,12 @@ local M = {}
 
 ---@type TsAutotag.Config
 M.config = {
+	aliases = {
+    razor = "html",
+    cshtml = "html",
+    htmlangular = "html",
+  },
+
 	opening_node_types = {
 		-- templ
 		"tag_start",

--- a/lua/ts-autotag/rename_tag/auto.lua
+++ b/lua/ts-autotag/rename_tag/auto.lua
@@ -22,10 +22,14 @@ end
 
 ---@param bufnr integer
 local function update_sibling_extmarks(bufnr)
-	local ok, parser = pcall(vim.treesitter.get_parser, bufnr)
+	local aliased_lang = ts.get_aliased_lang(bufnr)
+	local ok, parser = pcall(vim.treesitter.get_parser, bufnr, aliased_lang)
 	if not ok or not parser then
 		return
 	end
+
+	-- Force parse to ensure tree is up to date
+	parser:parse()
 
 	local opening_node, closing_node = ts.get_opening_pair(bufnr)
 	if not opening_node or not closing_node then

--- a/lua/ts-autotag/rename_tag/input.lua
+++ b/lua/ts-autotag/rename_tag/input.lua
@@ -6,7 +6,8 @@ local M = {}
 ---@param silent boolean
 ---@return TSNode?, TSNode?, boolean?
 local function get_pair(bufnr, silent)
-	local ok, parser = pcall(vim.treesitter.get_parser, bufnr)
+	local aliased_lang = ts.get_aliased_lang(bufnr)
+	local ok, parser = pcall(vim.treesitter.get_parser, bufnr, aliased_lang)
 	if not ok or not parser then
 		if not silent then
 			print("TS parser not found")

--- a/lua/ts-autotag/ts.lua
+++ b/lua/ts-autotag/ts.lua
@@ -2,11 +2,28 @@ local config = require("ts-autotag.config")
 
 local M = {}
 
+---@param bufnr integer
+---@return string
+function M.get_aliased_lang(bufnr)
+	local filetype = vim.api.nvim_get_option_value("filetype", { buf = bufnr })
+	return config.config.aliases[filetype] or filetype
+end
+
 ---@param opts vim.treesitter.get_node.Opts
 ---@param types string[]
 ---@param depth integer
 ---@return TSNode?
 function M.get_node(opts, types, depth)
+  -- Get aliased language if any
+  local aliased_lang = M.get_aliased_lang(opts.bufnr)
+  opts = vim.tbl_extend("force", opts, { lang = aliased_lang })
+
+  -- If no pos is provided, use current cursor position
+  if not opts.pos then
+    local cursor = vim.api.nvim_win_get_cursor(0)
+    opts.pos = { cursor[1] - 1, cursor[2] }
+  end
+
 	local current = vim.treesitter.get_node(opts)
 	if not current then
 		return

--- a/plugin/ts-autotag.nvim.lua
+++ b/plugin/ts-autotag.nvim.lua
@@ -1,4 +1,5 @@
 vim.api.nvim_create_autocmd("FileType", {
+	group = vim.api.nvim_create_augroup("ts-autotag.nvim/init", {}),
 	pattern = {
 		"typescript",
 		"javascript",
@@ -7,6 +8,9 @@ vim.api.nvim_create_autocmd("FileType", {
 		"xml",
 		"html",
 		"templ",
+		"razor",
+		"cshtml",
+    "htmlangular",
 	},
 	callback = function(ev)
 		local config = require("ts-autotag.config")


### PR DESCRIPTION
Hi

This PR introduces support for filetype aliases.

Currently, the aliases are hardcoded in the main config because they aren’t accessible during plugin filetype lazy initialization. This is a limitation of the current approach.

A more robust solution would be to move the configuration to something like `vim.g.tsautotag`, which would allow all user-defined filetypes to be properly initialized. However, I chose not to make such a major change in this PR to keep the scope smaller.

If you don’t want to support this feature, that’s completely fine - I just needed it for my own usage and wanted to share the implementation.

Any feedback is welcome.