### PR TITLE
fix: index out of bounds and executing macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ Default config
 			"tag_end",
 		},
 	},
+	-- Return false to disable this plugin for a buffer,
+	-- which is useful for large buffers.
+	should_attach = function(buf) return true end
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -127,8 +127,7 @@ Default config
 			"tag_end",
 		},
 	},
-	-- Return false to disable this plugin for a buffer,
-	-- which is useful for large buffers.
+	-- disable plugin on some buffers
 	should_attach = function(buf) return true end
 }
 ```

--- a/lua/ts-autotag/close_tag.lua
+++ b/lua/ts-autotag/close_tag.lua
@@ -1,5 +1,5 @@
 local ts = require("ts-autotag.ts")
-local config = require("ts-autotag.config")
+local u = require('ts-autotag.utils')
 
 local M = {}
 
@@ -42,7 +42,7 @@ vim.on_key(function(_, typed)
     if typed ~= ">" or vim.api.nvim_get_mode().mode ~= "i" then
         return
     end
-    if config.config.disable_in_macro and vim.fn.reg_recording() ~= "" then
+    if u.disabled() then
         return
     end
 

--- a/lua/ts-autotag/close_tag.lua
+++ b/lua/ts-autotag/close_tag.lua
@@ -35,14 +35,14 @@ end
 
 vim.on_key(function(_, typed)
     local buf = vim.api.nvim_get_current_buf()
+    if u.disabled(buf) then
+        return
+    end
     if not vim.b[buf].__autotag_close_tag_enabled then
         return
     end
 
     if typed ~= ">" or vim.api.nvim_get_mode().mode ~= "i" then
-        return
-    end
-    if u.disabled() then
         return
     end
 

--- a/lua/ts-autotag/close_tag.lua
+++ b/lua/ts-autotag/close_tag.lua
@@ -1,5 +1,5 @@
 local ts = require("ts-autotag.ts")
-local u = require('ts-autotag.utils')
+local u = require("ts-autotag.utils")
 
 local M = {}
 

--- a/lua/ts-autotag/close_tag.lua
+++ b/lua/ts-autotag/close_tag.lua
@@ -1,5 +1,5 @@
 local ts = require("ts-autotag.ts")
-local u = require("ts-autotag.utils")
+local config = require("ts-autotag.config")
 
 local M = {}
 
@@ -35,14 +35,14 @@ end
 
 vim.on_key(function(_, typed)
     local buf = vim.api.nvim_get_current_buf()
-    if u.disabled(buf) then
-        return
-    end
     if not vim.b[buf].__autotag_close_tag_enabled then
         return
     end
 
     if typed ~= ">" or vim.api.nvim_get_mode().mode ~= "i" then
+        return
+    end
+    if config.is_disabled_executing_macro() then
         return
     end
 

--- a/lua/ts-autotag/config.lua
+++ b/lua/ts-autotag/config.lua
@@ -1,5 +1,10 @@
 local M = {}
 
+---@return boolean
+function M.is_disabled_executing_macro()
+    return M.config.disable_in_macro and (vim.fn.reg_recording() ~= "" or vim.fn.reg_executing() ~= "")
+end
+
 ---@type TsAutotag.Config
 M.config = {
     opening_node_types = {
@@ -64,7 +69,10 @@ M.config = {
             "tag_end",
         },
     },
-    should_attach = function(_) return true end
+
+    should_attach = function()
+        return true
+    end,
 }
 
 return M

--- a/lua/ts-autotag/config.lua
+++ b/lua/ts-autotag/config.lua
@@ -64,6 +64,7 @@ M.config = {
             "tag_end",
         },
     },
+    should_attach = function(_) return true end
 }
 
 return M

--- a/lua/ts-autotag/init.lua
+++ b/lua/ts-autotag/init.lua
@@ -10,7 +10,7 @@ local M = {}
 ---@field auto_rename TsAutotag.Config.AutoRename
 ---@field auto_close TsAutotag.Config.AutoClose?
 ---@field filetypes string[]
----@field should_attach function(buf:integer) boolean
+---@field should_attach fun(buf: integer): boolean
 
 ---@class TsAutotag.Config.AutoRename
 ---@field enabled boolean

--- a/lua/ts-autotag/init.lua
+++ b/lua/ts-autotag/init.lua
@@ -10,6 +10,7 @@ local M = {}
 ---@field auto_rename TsAutotag.Config.AutoRename
 ---@field auto_close TsAutotag.Config.AutoClose?
 ---@field filetypes string[]
+---@field should_attach function(buf:integer) boolean
 
 ---@class TsAutotag.Config.AutoRename
 ---@field enabled boolean

--- a/lua/ts-autotag/rename_tag/auto.lua
+++ b/lua/ts-autotag/rename_tag/auto.lua
@@ -1,6 +1,5 @@
 local ts = require("ts-autotag.ts")
 local config = require("ts-autotag.config")
-local u = require("ts-autotag.utils")
 
 local M = {}
 
@@ -175,7 +174,7 @@ function M.init(buf)
         group = augroup,
         buffer = buf,
         callback = function(ev)
-            if u.disabled(ev.buf) then
+            if config.is_disabled_executing_macro() then
                 return
             end
 
@@ -188,12 +187,12 @@ function M.init(buf)
         group = augroup,
         buffer = buf,
         callback = vim.schedule_wrap(function(ev)
-            if u.disabled(ev.buf) then
+            -- race condition fix
+            if vim.api.nvim_get_current_buf() ~= ev.buf then
                 return
             end
 
-            -- race condition fix
-            if vim.api.nvim_get_current_buf() ~= ev.buf then
+            if config.is_disabled_executing_macro() then
                 return
             end
 

--- a/lua/ts-autotag/rename_tag/auto.lua
+++ b/lua/ts-autotag/rename_tag/auto.lua
@@ -121,7 +121,13 @@ local function sync_pair(bufnr, pair_id_offset)
         return
     end
 
-    local text1 = vim.api.nvim_buf_get_text(bufnr, ext1[2], ext1[3] - 1, ext1[4].end_row, ext1[4].end_col, {})[1]
+    -- For deleting, "vim.api.nvim_buf_get_text" may give "Index out of bounds"
+    local ok, text = pcall(vim.api.nvim_buf_get_text, bufnr, ext1[2], ext1[3] - 1, ext1[4].end_row, ext1[4].end_col, {})
+    if not ok then
+        clear_extmarks(bufnr)
+        return
+    end
+    local text1 = text[1]
     if text1:sub(1, 1) ~= "<" and text1:sub(1, 1) ~= "/" then
         clear_extmarks(bufnr)
         return
@@ -168,7 +174,7 @@ function M.init(buf)
         group = augroup,
         buffer = buf,
         callback = function(ev)
-            if config.config.disable_in_macro and vim.fn.reg_recording() ~= "" then
+            if config.config.disable_in_macro and (vim.fn.reg_recording() ~= "" or vim.fn.reg_executing() ~= "") then
                 return
             end
 

--- a/lua/ts-autotag/rename_tag/auto.lua
+++ b/lua/ts-autotag/rename_tag/auto.lua
@@ -175,7 +175,7 @@ function M.init(buf)
         group = augroup,
         buffer = buf,
         callback = function(ev)
-            if u.disabled() then
+            if u.disabled(ev.buf) then
                 return
             end
 
@@ -188,12 +188,12 @@ function M.init(buf)
         group = augroup,
         buffer = buf,
         callback = vim.schedule_wrap(function(ev)
-            -- race condition fix
-            if vim.api.nvim_get_current_buf() ~= ev.buf then
+            if u.disabled(ev.buf) then
                 return
             end
 
-            if u.disabled() then
+            -- race condition fix
+            if vim.api.nvim_get_current_buf() ~= ev.buf then
                 return
             end
 

--- a/lua/ts-autotag/rename_tag/auto.lua
+++ b/lua/ts-autotag/rename_tag/auto.lua
@@ -1,5 +1,6 @@
 local ts = require("ts-autotag.ts")
 local config = require("ts-autotag.config")
+local u = require("ts-autotag.utils")
 
 local M = {}
 
@@ -174,7 +175,7 @@ function M.init(buf)
         group = augroup,
         buffer = buf,
         callback = function(ev)
-            if config.config.disable_in_macro and (vim.fn.reg_recording() ~= "" or vim.fn.reg_executing() ~= "") then
+            if u.disabled() then
                 return
             end
 
@@ -192,7 +193,7 @@ function M.init(buf)
                 return
             end
 
-            if config.config.disable_in_macro and vim.fn.reg_recording() ~= "" then
+            if u.disabled() then
                 return
             end
 

--- a/lua/ts-autotag/utils/init.lua
+++ b/lua/ts-autotag/utils/init.lua
@@ -1,8 +1,9 @@
 local M = {}
 
-function M.disabled()
-    return require("ts-autotag.config").config.disable_in_macro
-        and (vim.fn.reg_recording() ~= "" or vim.fn.reg_executing() ~= "")
+function M.disabled(buf)
+    local c = require("ts-autotag.config").config
+    return c.disable_in_macro
+        and (vim.fn.reg_recording() ~= "" or vim.fn.reg_executing() ~= "") or not c.should_attach(buf)
 end
 
 return M

--- a/lua/ts-autotag/utils/init.lua
+++ b/lua/ts-autotag/utils/init.lua
@@ -1,9 +1,0 @@
-local M = {}
-
-function M.disabled(buf)
-    local c = require("ts-autotag.config").config
-    return c.disable_in_macro
-        and (vim.fn.reg_recording() ~= "" or vim.fn.reg_executing() ~= "") or not c.should_attach(buf)
-end
-
-return M

--- a/lua/ts-autotag/utils/init.lua
+++ b/lua/ts-autotag/utils/init.lua
@@ -1,0 +1,8 @@
+local M = {}
+
+function M.disabled()
+    return require("ts-autotag.config").config.disable_in_macro
+        and (vim.fn.reg_recording() ~= "" or vim.fn.reg_executing() ~= "")
+end
+
+return M

--- a/plugin/ts-autotag.nvim.lua
+++ b/plugin/ts-autotag.nvim.lua
@@ -4,6 +4,11 @@ vim.api.nvim_create_autocmd("FileType", {
     group = augroup,
     callback = function(event)
         local config = require("ts-autotag.config").config
+
+        if not config.should_attach(event.buf) then
+            return
+        end
+
         if vim.tbl_contains(config.filetypes, event.match) then
             if config.auto_rename.enabled then
                 require("ts-autotag.rename_tag.auto").init(event.buf)


### PR DESCRIPTION
For deletion, this function may give "index out of bounds" errors. We should disable rename in macro executing, too.